### PR TITLE
Fixed string formatting when raising ValueError

### DIFF
--- a/aionotify/base.py
+++ b/aionotify/base.py
@@ -52,7 +52,7 @@ class Watcher:
         if alias is None:
             alias = path
         if alias in self.requests:
-            raise ValueError("A watch request is already scheduled for alias %s" % alias)
+            raise ValueError("A watch request is already scheduled for alias %s" % (alias, ))
         self.requests[alias] = (path, flags)
         if self._fd is not None:
             # We've started, register the watch immediately.


### PR DESCRIPTION
If one wants to use tuple as value for alias:
```python
watcher.watch(file, flags, alias=('myfile', 'mylabel'))
```
he gets incorrect error message:

```
TypeError: not all arguments converted during string formatting
```

Instead of 

```
ValueError: A watch request is already scheduled for alias ('myfile', 'mylabel')
```