### PR TITLE
Include errno in exception message for inotify_add_watch

### DIFF
--- a/aionotify/base.py
+++ b/aionotify/base.py
@@ -75,8 +75,8 @@ class Watcher:
         assert alias not in self.descriptors, "Registering alias %s twice!" % alias
         wd = LibC.inotify_add_watch(self._fd, path, flags)
         if wd < 0:
-            raise IOError("Error setting up watch on %s with flags %s: wd=%s" % (
-                path, flags, wd))
+            raise IOError("Error setting up watch on %s with flags %s: errno=%d" % (
+                path, flags, ctypes.get_errno()))
         self.descriptors[alias] = wd
         self.aliases[wd] = alias
 

--- a/aionotify/base.py
+++ b/aionotify/base.py
@@ -65,7 +65,8 @@ class Watcher:
         wd = self.descriptors[alias]
         errno = LibC.inotify_rm_watch(self._fd, wd)
         if errno != 0:
-            raise IOError("Failed to close watcher %d: errno=%d" % (wd, errno))
+            raise IOError("Failed to close watcher %d: errno=%d" % (
+                wd, ctypes.get_errno()))
         del self.descriptors[alias]
         del self.requests[alias]
         del self.aliases[wd]
@@ -86,6 +87,9 @@ class Watcher:
         self._loop = loop
 
         self._fd = LibC.inotify_init()
+        if self._fd < 0:
+            raise IOError("Error setting up inotify on loop %s: errno=%d" % (
+                loop, ctypes.get_errno()))
         for alias, (path, flags) in self.requests.items():
             self._setup_watch(alias, path, flags)
 

--- a/aionotify/base.py
+++ b/aionotify/base.py
@@ -12,7 +12,7 @@ from . import aioutils
 Event = collections.namedtuple('Event', ['flags', 'cookie', 'name', 'alias'])
 
 
-_libc = ctypes.cdll.LoadLibrary('libc.so.6')
+_libc = ctypes.CDLL('libc.so.6', use_errno=True)
 
 
 class LibC:


### PR DESCRIPTION
My code is hitting this exception:

https://github.com/rbarrois/aionotify/blob/a953108b0556ba9f0dab5b1f18eae2abe19fb4a4/aionotify/base.py#L78

According to [the man page](https://linux.die.net/man/2/inotify_add_watch), `wd` is always -1 if an error occurs and the reason for the error is included in errno. With this patch, the exception message includes errno instead of `wd`.