### PR TITLE
Remove request on IN_IGNORED event

### DIFF
--- a/aionotify/base.py
+++ b/aionotify/base.py
@@ -6,7 +6,7 @@ import collections
 import ctypes
 import struct
 
-from . import aioutils
+from . import aioutils, enums
 
 Event = collections.namedtuple('Event', ['flags', 'cookie', 'name', 'alias'])
 
@@ -121,10 +121,16 @@ class Watcher:
                 # Event for a removed watch, skip it.
                 continue
 
+            alias = self.aliases[wd]
+            if flags & enums.Flags.IGNORED:
+                del self.descriptors[alias]
+                del self.requests[alias]
+                del self.aliases[wd]
+
             decoded_path = struct.unpack('%ds' % length, path)[0].rstrip(b'\x00').decode('utf-8')
             return Event(
                 flags=flags,
                 cookie=cookie,
                 name=decoded_path,
-                alias=self.aliases[wd],
+                alias=alias,
             )

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -57,6 +57,14 @@ class AIONotifyTestCase(unittest.IsolatedAsyncioTestCase):
         path = os.path.join(parent or self.testdir, filename)
         os.unlink(path)
 
+    def _mkdir(self, dirname, *, parent=None):
+        path = os.path.join(parent or self.testdir, dirname)
+        os.mkdir(path)
+
+    def _rmdir(self, dirname, *, parent=None):
+        path = os.path.join(parent or self.testdir, dirname)
+        os.rmdir(path)
+
     def _rename(self, source, target, *, parent=None):
         source_path = os.path.join(parent or self.testdir, source)
         target_path = os.path.join(parent or self.testdir, target)
@@ -199,6 +207,24 @@ class SimpleUsageTests(AIONotifyTestCase):
 
         # And it's over.
         await self._assert_no_events()
+
+    @asyncio.coroutine
+    def test_remove_directory(self):
+        """ A deleted file or directory should be unwatched."""
+        full_path = os.path.join(self.testdir, 'a')
+        self._mkdir('a')
+        self.watcher.watch(full_path, aionotify.Flags.IGNORED)
+        yield from self.watcher.setup(self.loop)
+
+        self._rmdir('a')
+        event = yield from self.watcher.get_event()
+        self._assert_file_event(event, '', flags=aionotify.Flags.IGNORED, alias=full_path)
+
+        # Make sure we can watch the same path again (#2)
+        self._mkdir('a')
+        self.watcher.watch(full_path, aionotify.Flags.IGNORED)
+
+        yield from self._assert_no_events()
 
 
 class ErrorTests(AIONotifyTestCase):


### PR DESCRIPTION
Fix internal state when an IN_IGNORED event happens. This allows the user to decide what to do (whether to re-add the watch later, or simply note that it's gone away).

Fixes #2 