### PR TITLE
Allow watching a file that didn't exist before

### DIFF
--- a/aionotify/base.py
+++ b/aionotify/base.py
@@ -53,10 +53,10 @@ class Watcher:
             alias = path
         if alias in self.requests:
             raise ValueError("A watch request is already scheduled for alias %s" % alias)
-        self.requests[alias] = (path, flags)
         if self._fd is not None:
             # We've started, register the watch immediately.
             self._setup_watch(alias, path, flags)
+        self.requests[alias] = (path, flags)
 
     def unwatch(self, alias):
         """Stop watching a given rule."""

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -197,6 +197,20 @@ class SimpleUsageTests(AIONotifyTestCase):
         # And it's over.
         yield from self._assert_no_events()
 
+    @asyncio.coroutine
+    def test_watch_after_created(self):
+        """It should be possible to retry watching a file that didn't exist."""
+        yield from self.watcher.setup(self.loop)
+
+        full_path = os.path.join(self.testdir, 'a')
+        with self.assertRaises(OSError):
+            self.watcher.watch(full_path, aionotify.Flags.MODIFY)
+
+        self._touch('a')
+        self.watcher.watch(full_path, aionotify.Flags.MODIFY)
+
+        yield from self._assert_no_events()
+
 
 class ErrorTests(AIONotifyTestCase):
     """Test error cases."""


### PR DESCRIPTION
If a watch request fails because the file didn't exist, an `OSError` is
correctly raised, but the alias remains in the list of requests.
Therefore it isn't possible to catch the exception, and retry the watch
request once the file has been created.

This patch adds the watch request to the request queue after attempting
to call `_setup_watch`, to ensure it doesn't get left in the queue if
the setup fails.