### PR TITLE
Changed @asyncio.coroutine to async def as it's deprecated in newer Python versions 

### DIFF
--- a/aionotify/aioutils.py
+++ b/aionotify/aioutils.py
@@ -119,8 +119,8 @@ class UnixFileDescriptorTransport(asyncio.ReadTransport):
         return '<%s>' % ' '.join(parts)
 
 
-@asyncio.coroutine
-def stream_from_fd(fd, loop):
+
+async def stream_from_fd(fd, loop):
     """Recieve a streamer for a given file descriptor."""
     reader = asyncio.StreamReader(loop=loop)
     protocol = asyncio.StreamReaderProtocol(reader, loop=loop)


### PR DESCRIPTION
Hello,
I have discovered that this file uses the deprecated 
`@asyncio.coroutine` 
command, which isn't supported in Python <= 3.11.
This lead to a problem in Home Assistant (https://github.com/home-assistant/core/issues/94215) which I found after Home Assistant updated Python to 3.11.
Note that this is my first pull request, so I eventually did things wrong.

After some research, I found the solution here:
`https://stackoverflow.com/questions/74345065/attributeerror-module-asyncio-has-no-attribute-coroutine-in-python-3-11`

Best regards
Aaron Eisele