### PR TITLE
Convert to anyio

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,10 @@ Its use is quite simple:
 
     anyio.run(work)
 
+    # alternately:
+    # asyncio.run(work())
+    # trio.run(work)
+
 
 Links
 -----

--- a/README.rst
+++ b/README.rst
@@ -29,16 +29,17 @@ Its use is quite simple:
     import aionotify
 
     # Setup the watcher
-    watcher = aionotify.Watcher()
-    watcher.watch(alias='logs', path='/var/log', flags=aionotify.Flags.MODIFY)
 
     async def work():
-        await watcher.setup()
-        for _i in range(10):
-            # Pick the 10 first events
-            event = await watcher.get_event()
-            print(event)
-        watcher.close()
+        async with aionotify.Watcher() as watcher:
+            await watcher.awatch(alias='logs', path='/var/log', flags=aionotify.Flags.MODIFY)
+            i = 0
+            async for event in watcher:
+                # Pick the 10 first events
+                print(event)
+                i += 1
+                if i >= 10:
+                    return
 
     anyio.run(work)
 

--- a/README.rst
+++ b/README.rst
@@ -18,14 +18,14 @@ aionotify
     :alt: License
 
 
-``aionotify`` is a simple, asyncio-based inotify library.
+``aionotify`` is a simple, anyio-based inotify library.
 
 
 Its use is quite simple:
 
 .. code-block:: python
 
-    import asyncio
+    import anyio
     import aionotify
 
     # Setup the watcher
@@ -40,7 +40,7 @@ Its use is quite simple:
             print(event)
         watcher.close()
 
-    asyncio.run(work())
+    anyio.run(work)
 
 
 Links

--- a/aionotify/__init__.py
+++ b/aionotify/__init__.py
@@ -1,13 +1,8 @@
 # Copyright (c) 2016 The aionotify project
 # This code is distributed under the two-clause BSD License.
 
-from importlib.metadata import version
-
 from .enums import Flags
 from .base import Watcher
 
 __all__ = ['Flags', 'Watcher']
 
-
-__version__ = version("aionotify")
-__author__ = 'Raphaël Barrois <raphael.barrois+aionotify@polytechnique.org>'

--- a/aionotify/__init__.py
+++ b/aionotify/__init__.py
@@ -5,4 +5,3 @@ from .enums import Flags
 from .base import Watcher
 
 __all__ = ['Flags', 'Watcher']
-

--- a/aionotify/aioutils.py
+++ b/aionotify/aioutils.py
@@ -39,9 +39,12 @@ class UnixFileDescriptorStream:
             self._pos = pos
         return res
 
-    async def aclose(self):
+    def close(self):
         os.close(self._fileno)
         self._fileno = None
+
+    async def aclose(self):
+        self.close()
 
     def __repr__(self):
         parts = [

--- a/aionotify/aioutils.py
+++ b/aionotify/aioutils.py
@@ -2,7 +2,6 @@
 # This code is distributed under the two-clause BSD License.
 
 import anyio
-import errno
 import logging
 import os
 
@@ -31,7 +30,7 @@ class UnixFileDescriptorStream:
             self._buf = os.read(self._fileno, self.max_size)
 
         pos = self._pos
-        res = self._buf[pos:pos+nbytes]
+        res = self._buf[pos:(pos + nbytes)]
         pos += nbytes
         if pos >= len(self._buf):
             self.pos = 0
@@ -50,4 +49,3 @@ class UnixFileDescriptorStream:
             'fd=%s' % self._fileno,
         ]
         return '<%s>' % ' '.join(parts)
-

--- a/aionotify/aioutils.py
+++ b/aionotify/aioutils.py
@@ -1,142 +1,53 @@
 # Copyright (c) 2016 The aionotify project
 # This code is distributed under the two-clause BSD License.
 
-import asyncio
-import asyncio.futures
+import anyio
 import errno
 import logging
 import os
 
-logger = logging.getLogger('asyncio.aionotify')
+logger = logging.getLogger('aionotify.aioutils')
 
 
-class UnixFileDescriptorTransport(asyncio.ReadTransport):
-    # Inspired from asyncio.unix_events._UnixReadPipeTransport
-    max_size = 1024
+class UnixFileDescriptorStream:
+    """
+    A simple buffering adapter from a Unix file descriptor to an anyio bytestream.
 
-    def __init__(self, loop, fileno, protocol, waiter=None):
+    This class takes ownership of the descriptor.
+    """
+    max_size = 4096
+
+    def __init__(self, fileno):
         super().__init__()
-        self._loop = loop
         self._fileno = fileno
-        self._protocol = protocol
+        self._buf = b""
+        self._pos = 0
 
-        self._active = False
-        self._closing = False
+    async def read(self, nbytes):
+        """whenever the fd is ready for reading."""
 
-        self._loop.call_soon(self._protocol.connection_made, self)
-        # only start reading when connection_made() has been called.
-        self._loop.call_soon(self.resume_reading)
-        if waiter is not None:
-            # only wake up the waiter when connection_made() has been called.
-            self._loop.call_soon(self._notify_waiter, waiter)
+        if not self._buf:
+            await anyio.wait_readable(self._fileno)
+            self._buf = os.read(self._fileno, self.max_size)
 
-    def _notify_waiter(self, waiter):
-        if not waiter.cancelled():
-            waiter.set_result(None)
-
-    def _read_ready(self):
-        """Called by the event loop whenever the fd is ready for reading."""
-
-        try:
-            data = os.read(self._fileno, self.max_size)
-        except InterruptedError:
-            # No worries ;)
-            pass
-        except OSError as exc:
-            # Some OS-level problem, crash.
-            self._fatal_error(exc, "Fatal read error on file descriptor read")
+        pos = self._pos
+        res = self._buf[pos:pos+nbytes]
+        pos += nbytes
+        if pos >= len(self._buf):
+            self.pos = 0
+            self._buf = b''
         else:
-            if data:
-                self._protocol.data_received(data)
-            else:
-                # We reached end-of-file.
-                if self._loop.get_debug():
-                    logger.info("%r was closed by the kernel", self)
-                self._closing = False
-                self.pause_reading()
-                self._loop.call_soon(self._protocol.eof_received)
-                self._loop.call_soon(self._call_connection_lost, None)
+            self._pos = pos
+        return res
 
-    def pause_reading(self):
-        """Public API: pause reading the transport."""
-        self._loop.remove_reader(self._fileno)
-        self._active = False
-
-    def resume_reading(self):
-        """Public API: resume transport reading."""
-        self._loop.add_reader(self._fileno, self._read_ready)
-        self._active = True
-
-    def close(self):
-        """Public API: close the transport."""
-        if not self._closing:
-            self._close()
-
-    def _fatal_error(self, exc, message):
-        if isinstance(exc, OSError) and exc.errno == errno.EIO:
-            if self._loop.get_debug():
-                logger.debug("%r: %s", self, message, exc_info=True)
-        else:
-            self._loop.call_exception_handler({
-                'message': message,
-                'exception': exc,
-                'transport': self,
-                'protocol': self._protocol,
-            })
-        self._close(error=exc)
-
-    def _close(self, error=None):
-        """Actual closing code, both from manual close and errors."""
-        self._closing = True
-        self.pause_reading()
-        self._loop.call_soon(self._call_connection_lost, error)
-
-    def _call_connection_lost(self, error):
-        """Finalize closing."""
-        try:
-            self._protocol.connection_lost(error)
-        finally:
-            os.close(self._fileno)
-            self._fileno = None
-            self._protocol = None
-            self._loop = None
+    async def aclose(self):
+        os.close(self._fileno)
+        self._fileno = None
 
     def __repr__(self):
-        if self._active:
-            status = 'active'
-        elif self._closing:
-            status = 'closing'
-        elif self._fileno:
-            status = 'paused'
-        else:
-            status = 'closed'
-
         parts = [
             self.__class__.__name__,
-            status,
             'fd=%s' % self._fileno,
         ]
         return '<%s>' % ' '.join(parts)
 
-
-async def stream_from_fd(fd, loop):
-    """Recieve a streamer for a given file descriptor."""
-    reader = asyncio.StreamReader(loop=loop)
-    protocol = asyncio.StreamReaderProtocol(reader, loop=loop)
-    waiter = asyncio.futures.Future(loop=loop)
-
-    transport = UnixFileDescriptorTransport(
-        loop=loop,
-        fileno=fd,
-        protocol=protocol,
-        waiter=waiter,
-    )
-
-    try:
-        await waiter
-    except Exception:
-        transport.close()
-
-    if loop.get_debug():
-        logger.debug("Read fd %r connected: (%r, %r)", fd, transport, protocol)
-    return reader, transport

--- a/aionotify/base.py
+++ b/aionotify/base.py
@@ -35,7 +35,7 @@ PREFIX = struct.Struct('iIII')
 class Watcher:
     max_size = 1024
 
-    _fd:int = None
+    _fd: int = None
     _stream: UnixFileDescriptorStream = None
 
     def __init__(self):

--- a/aionotify/base.py
+++ b/aionotify/base.py
@@ -60,11 +60,18 @@ class Watcher:
 
     async def __aexit__(self, *exc):
         # This assumes that closing the inotify stream doesn't block
-        await self._stream.aclose()
+        self.close()
+
+    setup = __aenter__  # deprecated
+
+    def _close(self):
+        self._stream.close()
         self._fd = None
         self._stream = None
 
         self._reset()
+
+    close = _close  # deprecated
 
     def watch(self, path, flags, *, alias=None):
         """Add a new watching rule.

--- a/examples/print.py
+++ b/examples/print.py
@@ -6,7 +6,6 @@
 import aionotify
 import argparse
 import anyio
-import logging
 
 
 class Example:
@@ -27,6 +26,7 @@ class Example:
                 i += 1
                 if i >= max_events:
                     return
+
 
 def main(args):
     example = Example()

--- a/examples/print.py
+++ b/examples/print.py
@@ -5,9 +5,8 @@
 
 import aionotify
 import argparse
-import asyncio
+import anyio
 import logging
-import signal
 
 
 class Example:
@@ -20,57 +19,29 @@ class Example:
         self.watcher = aionotify.Watcher()
         self.watcher.watch(path, aionotify.Flags.MODIFY | aionotify.Flags.CREATE | aionotify.Flags.DELETE)
 
-    @asyncio.coroutine
-    def _run(self, max_events):
-        yield from self.watcher.setup(self.loop)
-        for _i in range(max_events):
-            event = yield from self.watcher.get_event()
-            print(event.name, aionotify.Flags.parse(event.flags))
-        self.shutdown()
-
-    def run(self, loop, max_events):
-        self.loop = loop
-        self.task = loop.create_task(self._run(max_events))
-
-    def shutdown(self):
-        self.watcher.close()
-        if self.task is not None:
-            self.task.cancel()
-        self.loop.stop()
-
-
-def setup_signal_handlers(loop, example):
-    for sig in [signal.SIGINT, signal.SIGTERM]:
-        loop.add_signal_handler(sig, example.shutdown)
-
+    async def run(self, max_events):
+        async with self.watcher:
+            i = 0
+            async for event in self.watcher:
+                print(event.name, aionotify.Flags.parse(event.flags))
+                i += 1
+                if i >= max_events:
+                    return
 
 def main(args):
-    if args.debug:
-        logger = logging.getLogger('asyncio')
-        logger.setLevel(logging.DEBUG)
-        logger.addHandler(logging.StreamHandler())
-
     example = Example()
     example.prepare(args.path)
 
-    loop = asyncio.get_event_loop()
-    if args.debug:
-        loop.set_debug(True)
-
-    setup_signal_handlers(loop, example)
-    example.run(loop, args.events)
-
     try:
-        loop.run_forever()
-    finally:
-        loop.close()
+        anyio.run(example.run, args.events)
+    except* KeyboardInterrupt:
+        pass
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('path', help="Path to watch")
     parser.add_argument('--events', default=10, type=int, help="Number of arguments before shutdown")
-    parser.add_argument('-d', '--debug', action='store_true', help="Enable asyncio debugging.")
 
     args = parser.parse_args()
     main(args)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]
 name = aionotify
 version = 0.3.2.dev0
-description = Asyncio-powered inotify library
+description = Async inotify library
 long_description = file: README.rst
 # https://docutils.sourceforge.io/FAQ.html#what-s-the-official-mime-type-for-restructuredtext-data
 long_description_content_type = text/x-rst
 author = Raphaël Barrois
 author_email = raphael.barrois+aionotify@polytechnique.org
 url = https://github.com/rbarrois/aionotify
-keywords = asyncio, inotify
+keywords = asyncio, anyio, trio, inotify
 license = BSD
 license_file = LICENSE
 classifiers =
@@ -29,6 +29,9 @@ zip_safe = false
 packages = aionotify
 python_requires = >= 3.8
 install_requires =
+    anyio>=4.7
+tests_require =
+    pytest
 
 [options.extras_require]
 dev =

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,66 +1,44 @@
 # Copyright (c) 2016 The aionotify project
 # This code is distributed under the two-clause BSD License.
 
-import asyncio
+import anyio
 import logging
-import os
-import os.path
 import tempfile
-import unittest
+import pytest
 
 import aionotify
 
+pytestmark = pytest.mark.anyio
 
-AIODEBUG = bool(os.environ.get('PYTHONAIODEBUG') == '1')
-
-
-if AIODEBUG:
-    logger = logging.getLogger('asyncio')
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(logging.StreamHandler())
-
-
-TESTDIR = os.environ.get('AIOTESTDIR') or os.path.join(os.path.dirname(__file__), 'testevents')
-
-
-class AIONotifyTestCase(unittest.IsolatedAsyncioTestCase):
-    timeout = 3
-
-    def setUp(self):
-        self.loop = asyncio.get_event_loop()
-        if AIODEBUG:
-            self.loop.set_debug(True)
-        self.watcher = aionotify.Watcher()
-        self._testdir = tempfile.TemporaryDirectory(dir=TESTDIR)
-        self.testdir = self._testdir.name
-
-        # Schedule a loop shutdown
-        self.loop.call_later(self.timeout, self.loop.stop)
-
-    def tearDown(self):
-        if not self.watcher.closed:
-            self.watcher.close()
-        self._testdir.cleanup()
-        self.assertFalse(os.path.exists(self.testdir))
-
+class AIONotifyTestCase:
     # Utility functions
     # =================
 
     # Those allow for more readable tests.
 
+    @pytest.fixture(autouse=True)
+    def with_watcher(self):
+        self.watcher = aionotify.Watcher()
+
+    @pytest.fixture(autouse=True)
+    def with_tempdir(self, tmp_path):
+        self.testdir = tmp_path
+        yield
+        self.testdir = None
+
     def _touch(self, filename, *, parent=None):
-        path = os.path.join(parent or self.testdir, filename)
-        with open(path, 'w') as f:
-            f.write('')
+        path = (parent or self.testdir) / filename
+        with path.open('w') as f:
+            pass
 
     def _unlink(self, filename, *, parent=None):
-        path = os.path.join(parent or self.testdir, filename)
-        os.unlink(path)
+        path = (parent or self.testdir) / filename
+        path.unlink()
 
     def _rename(self, source, target, *, parent=None):
-        source_path = os.path.join(parent or self.testdir, source)
-        target_path = os.path.join(parent or self.testdir, target)
-        os.rename(source_path, target_path)
+        source_path = (parent or self.testdir) / source
+        target_path = (parent or self.testdir) / target
+        source_path.rename(target_path)
 
     def _assert_file_event(self, event, name, flags=aionotify.Flags.CREATE, alias=None):
         """Check for an expected file event.
@@ -70,159 +48,150 @@ class AIONotifyTestCase(unittest.IsolatedAsyncioTestCase):
         if alias is None:
             alias = self.testdir
 
-        self.assertEqual(name, event.name)
-        self.assertEqual(flags, event.flags)
-        self.assertEqual(alias, event.alias)
+        assert name == event.name
+        assert flags == event.flags
+        assert alias == event.alias
 
     async def _assert_no_events(self, timeout=0.1):
         """Ensure that no events are left in the queue."""
-        task = self.watcher.get_event()
-        try:
-            result = await asyncio.wait_for(task, timeout)
-        except asyncio.TimeoutError:
-            # All fine: we didn't receive any event.
-            pass
-        else:
+        with anyio.move_on_after(timeout):
+            result = await self.watcher.get_event()
             raise AssertionError("Event %r occurred within timeout %s" % (result, timeout))
 
 
-class SimpleUsageTests(AIONotifyTestCase):
+class TestSimpleUsage(AIONotifyTestCase):
 
     async def test_watch_before_start(self):
         """A watch call is valid before startup."""
         self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
-        await self.watcher.setup(self.loop)
+        async with self.watcher:
+            # Touch a file: we get the event.
+            self._touch('a')
+            event = await self.watcher.get_event()
+            self._assert_file_event(event, 'a')
 
-        # Touch a file: we get the event.
-        self._touch('a')
-        event = await self.watcher.get_event()
-        self._assert_file_event(event, 'a')
-
-        # And it's over.
-        await self._assert_no_events()
+            # And it's over.
+            await self._assert_no_events()
 
     async def test_watch_before_start_default_loop(self):
         """A watch call is valid before startup."""
         self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
-        await self.watcher.setup()
+        async with self.watcher:
 
-        # Touch a file: we get the event.
-        self._touch('a')
-        event = await self.watcher.get_event()
-        self._assert_file_event(event, 'a')
+            # Touch a file: we get the event.
+            self._touch('a')
+            event = await self.watcher.get_event()
+            self._assert_file_event(event, 'a')
 
-        # And it's over.
-        await self._assert_no_events()
+            # And it's over.
+            await self._assert_no_events()
 
     async def test_watch_after_start(self):
         """A watch call is valid after startup."""
-        await self.watcher.setup(self.loop)
-        self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
+        async with self.watcher:
+            self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
 
-        # Touch a file: we get the event.
-        self._touch('a')
-        event = await self.watcher.get_event()
-        self._assert_file_event(event, 'a')
+            # Touch a file: we get the event.
+            self._touch('a')
+            event = await self.watcher.get_event()
+            self._assert_file_event(event, 'a')
 
-        # And it's over.
-        await self._assert_no_events()
+            # And it's over.
+            await self._assert_no_events()
 
     async def test_event_ordering(self):
         """Events should arrive in the order files where created."""
-        await self.watcher.setup(self.loop)
-        self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
+        async with self.watcher:
+            self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
 
-        # Touch 2 files
-        self._touch('a')
-        self._touch('b')
+            # Touch 2 files
+            self._touch('a')
+            self._touch('b')
 
-        # Get the events
-        event1 = await self.watcher.get_event()
-        event2 = await self.watcher.get_event()
-        self._assert_file_event(event1, 'a')
-        self._assert_file_event(event2, 'b')
+            # Get the events
+            event1 = await self.watcher.get_event()
+            event2 = await self.watcher.get_event()
+            self._assert_file_event(event1, 'a')
+            self._assert_file_event(event2, 'b')
 
-        # And it's over.
-        await self._assert_no_events()
+            # And it's over.
+            await self._assert_no_events()
 
     async def test_filtering_events(self):
         """We only get targeted events."""
-        await self.watcher.setup(self.loop)
-        self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
-        self._touch('a')
-        event = await self.watcher.get_event()
-        self._assert_file_event(event, 'a')
+        async with self.watcher:
+            self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
+            self._touch('a')
+            event = await self.watcher.get_event()
+            self._assert_file_event(event, 'a')
 
-        # Perform a filtered-out event; we shouldn't see anything
-        self._unlink('a')
-        await self._assert_no_events()
+            # Perform a filtered-out event; we shouldn't see anything
+            self._unlink('a')
+            await self._assert_no_events()
 
     async def test_watch_unwatch(self):
         """Watches can be removed."""
         self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
-        await self.watcher.setup(self.loop)
+        async with self.watcher:
 
-        self.watcher.unwatch(self.testdir)
-        await asyncio.sleep(0.1)
+            self.watcher.unwatch(self.testdir)
 
-        # Touch a file; we shouldn't see anything.
-        self._touch('a')
-        await self._assert_no_events()
+            # Touch a file; we shouldn't see anything.
+            self._touch('a')
+            await self._assert_no_events()
 
     async def test_watch_unwatch_before_drain(self):
         """Watches can be removed, no events occur afterwards."""
         self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
-        await self.watcher.setup(self.loop)
+        async with self.watcher:
 
-        # Touch a file before unwatching
-        self._touch('a')
-        self.watcher.unwatch(self.testdir)
+            # Touch a file before unwatching
+            self._touch('a')
+            self.watcher.unwatch(self.testdir)
 
-        # We shouldn't see anything.
-        await self._assert_no_events()
+            # We shouldn't see anything.
+            await self._assert_no_events()
 
     async def test_rename_detection(self):
         """A file rename can be detected through event cookies."""
         self.watcher.watch(self.testdir, aionotify.Flags.MOVED_FROM | aionotify.Flags.MOVED_TO)
-        await self.watcher.setup(self.loop)
-        self._touch('a')
+        async with self.watcher:
+            self._touch('a')
 
-        # Rename a file => two events
-        self._rename('a', 'b')
-        event1 = await self.watcher.get_event()
-        event2 = await self.watcher.get_event()
+            # Rename a file => two events
+            self._rename('a', 'b')
+            event1 = await self.watcher.get_event()
+            event2 = await self.watcher.get_event()
 
-        # We got moved_from then moved_to; they share the same cookie.
-        self._assert_file_event(event1, 'a', aionotify.Flags.MOVED_FROM)
-        self._assert_file_event(event2, 'b', aionotify.Flags.MOVED_TO)
-        self.assertEqual(event1.cookie, event2.cookie)
+            # We got moved_from then moved_to; they share the same cookie.
+            self._assert_file_event(event1, 'a', aionotify.Flags.MOVED_FROM)
+            self._assert_file_event(event2, 'b', aionotify.Flags.MOVED_TO)
+            assert event1.cookie == event2.cookie
 
-        # And it's over.
-        await self._assert_no_events()
+            # And it's over.
+            await self._assert_no_events()
 
 
-class ErrorTests(AIONotifyTestCase):
+class TestErrors(AIONotifyTestCase):
     """Test error cases."""
 
     async def test_watch_nonexistent(self):
         """Watching a non-existent directory raises an OSError."""
-        badpath = os.path.join(self.testdir, 'nonexistent')
+        badpath = self.testdir / 'nonexistent'
         self.watcher.watch(badpath, aionotify.Flags.CREATE)
-        with self.assertRaises(OSError):
-            await self.watcher.setup(self.loop)
+        with pytest.raises(OSError):
+            async with self.watcher:
+                pass
+
+    async def test_watch_nonexistent2(self):
+        """Watching a non-existent directory raises an OSError."""
+        badpath = self.testdir / 'nonexistent'
+        async with self.watcher:
+            with pytest.raises(OSError):
+                self.watcher.watch(badpath, aionotify.Flags.CREATE)
 
     async def test_unwatch_bad_alias(self):
         self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
-        await self.watcher.setup(self.loop)
-        with self.assertRaises(ValueError):
-            self.watcher.unwatch('blah')
-
-
-class SanityTests(AIONotifyTestCase):
-    timeout = 0.1
-
-    @unittest.expectedFailure
-    async def test_timeout_works(self):
-        """A test cannot run longer than the defined timeout."""
-        # This test should fail, since we're setting a global timeout of 0.1 yet ask to wait for 0.3 seconds.
-        await asyncio.sleep(0.5)
+        async with self.watcher:
+            with pytest.raises(ValueError):
+                self.watcher.unwatch('blah')

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -73,9 +73,9 @@ class TestSimpleUsage(AIONotifyTestCase):
             # And it's over.
             await self._assert_no_events()
 
-    async def test_watch_before_start_default_loop(self):
+    async def test_watch_before_start_async(self):
         """A watch call is valid before startup."""
-        self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
+        await self.watcher.awatch(self.testdir, aionotify.Flags.CREATE)
         async with self.watcher:
 
             # Touch a file: we get the event.
@@ -90,6 +90,19 @@ class TestSimpleUsage(AIONotifyTestCase):
         """A watch call is valid after startup."""
         async with self.watcher:
             self.watcher.watch(self.testdir, aionotify.Flags.CREATE)
+
+            # Touch a file: we get the event.
+            self._touch('a')
+            event = await self.watcher.get_event()
+            self._assert_file_event(event, 'a')
+
+            # And it's over.
+            await self._assert_no_events()
+
+    async def test_watch_after_start_async(self):
+        """A watch call is valid after startup."""
+        async with self.watcher:
+            await self.watcher.awatch(self.testdir, aionotify.Flags.CREATE)
 
             # Touch a file: we get the event.
             self._touch('a')

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -2,13 +2,12 @@
 # This code is distributed under the two-clause BSD License.
 
 import anyio
-import logging
-import tempfile
 import pytest
 
 import aionotify
 
 pytestmark = pytest.mark.anyio
+
 
 class AIONotifyTestCase:
     # Utility functions
@@ -28,7 +27,7 @@ class AIONotifyTestCase:
 
     def _touch(self, filename, *, parent=None):
         path = (parent or self.testdir) / filename
-        with path.open('w') as f:
+        with path.open('w'):
             pass
 
     def _unlink(self, filename, *, parent=None):


### PR DESCRIPTION
This patch converts aionotify to anyio, thus it now works with asyncio *and* trio.

It also adds an `awatch` method because `watch` may block (it does take a file system path …).

The watcher is now an async context manager and can be iterated. Both are optional but strongly recommended IMHO.